### PR TITLE
Add warning to readme about renaming files

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ you can also add the property `annotation-target-type` and specify whether it is
 
 If you have [dataview](https://github.com/blacksmithgu/obsidian-dataview) installed, then you can also specify the annotation target with a dataview attribute. In this case, obsidian-style links can be used instead of a plain-text path. 
 
+> WARNING! Don't rename an original pdf or epub file! The plugin is going to lose the connection between annotations and file in that case.
+
 ### Annotating
 
 Annotation is self-explanatory. Select text with your mouse to get started. 


### PR DESCRIPTION
Hi! I was trying this plugin out and noticed that if you rename `epub` or `pdf` file in a vault, the plugin can't show you the file and annotations.

In the case of using the dataview plugin, relative obsidian links in the dataview attribute update automatically, so the plugin shows pdf as before but fails to show annotations in it. I guess it happens because the plugin gets document file path and title from JSON instead of extracting it from obsidian's link from attribute.

I'm not sure if it's possible to fix it, I'm not familiar with Obsidian plugin API at the moment, so I decided to add a warning to readme about that problem.