### PR TITLE
fix: check for decoded and encoded uri in loadAnnotationsAtUriFromFil…

### DIFF
--- a/src/annotationUtils.tsx
+++ b/src/annotationUtils.tsx
@@ -199,7 +199,8 @@ export function loadAnnotationsAtUriFromFileText(url: URL | null, fileText: stri
             //The check against SAMPLE_PDF_URL is for backwards compability.
             if (
                 url === null ||
-                annotationDocumentIdentifiers.includes(params.uri) ||
+                annotationDocumentIdentifiers.includes(encodeURI(params.uri)) ||
+                annotationDocumentIdentifiers.includes(decodeURI(params.uri)) ||
                 annotationDocumentIdentifiers.includes(SAMPLE_PDF_URL)
             ) {
                 rows.push(completeAnnotation);


### PR DESCRIPTION
fixes #70 

Not sure if this is everything that should happen but it's enough to make notes form both devices show up on both devices as well for me!