### PR TITLE
Add setting to choose default annotation mode

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -246,7 +246,7 @@ export default class AnnotatorPlugin extends Plugin implements IHasAnnotatorSett
                             state.type === 'markdown' &&
                             state.state?.file &&
                             self.pdfAnnotatorFileModes[this.id || state.state.file] !== 'markdown' &&
-                            self.settings.annotationModeByDefault === true
+                            self.settings.annotationMarkdownSettings.annotationModeByDefault === true
                         ) {
                             const file = self.app.vault.getAbstractFileByPath(state.state.file);
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -245,7 +245,8 @@ export default class AnnotatorPlugin extends Plugin implements IHasAnnotatorSett
                             self._loaded &&
                             state.type === 'markdown' &&
                             state.state?.file &&
-                            self.pdfAnnotatorFileModes[this.id || state.state.file] !== 'markdown'
+                            self.pdfAnnotatorFileModes[this.id || state.state.file] !== 'markdown' &&
+                            self.settings.annotationModeByDefault === true
                         ) {
                             const file = self.app.vault.getAbstractFileByPath(state.state.file);
 

--- a/src/settings.tsx
+++ b/src/settings.tsx
@@ -2,7 +2,6 @@ import AnnotatorPlugin from 'main';
 import { App, PluginSettingTab, Setting } from 'obsidian';
 
 export interface AnnotatorSettings {
-    annotationModeByDefault: boolean;
     deafultDarkMode: boolean;
     darkReaderSettings: {
         brightness: number;
@@ -11,6 +10,7 @@ export interface AnnotatorSettings {
     };
     customDefaultPath: string;
     annotationMarkdownSettings: {
+        annotationModeByDefault: boolean;
         includePrefix: boolean;
         highlightHighlightedText: boolean;
         includePostfix: boolean;
@@ -19,7 +19,6 @@ export interface AnnotatorSettings {
 }
 
 export const DEFAULT_SETTINGS: AnnotatorSettings = {
-    annotationModeByDefault: true,
     deafultDarkMode: false,
     darkReaderSettings: {
         brightness: 150,
@@ -29,6 +28,7 @@ export const DEFAULT_SETTINGS: AnnotatorSettings = {
     debugLogging: false,
     customDefaultPath: '',
     annotationMarkdownSettings: {
+        annotationModeByDefault: true,
         includePrefix: true,
         highlightHighlightedText: true,
         includePostfix: true
@@ -79,8 +79,8 @@ export default class AnnotatorSettingsTab extends PluginSettingTab {
             .setName('Use Annotation Mode By Default')
             .setDesc('Whether to use annotation mode by default when opening a note with annotation-target')
             .addToggle(toggle =>
-                toggle.setValue(this.plugin.settings.annotationModeByDefault).onChange(async value => {
-                    this.plugin.settings.annotationModeByDefault = value;
+                toggle.setValue(this.plugin.settings.annotationMarkdownSettings.annotationModeByDefault).onChange(async value => {
+                    this.plugin.settings.annotationMarkdownSettings.annotationModeByDefault = value;
                     await this.plugin.saveSettings();
                 })
             );

--- a/src/settings.tsx
+++ b/src/settings.tsx
@@ -2,6 +2,7 @@ import AnnotatorPlugin from 'main';
 import { App, PluginSettingTab, Setting } from 'obsidian';
 
 export interface AnnotatorSettings {
+    annotationModeByDefault: boolean;
     deafultDarkMode: boolean;
     darkReaderSettings: {
         brightness: number;
@@ -18,6 +19,7 @@ export interface AnnotatorSettings {
 }
 
 export const DEFAULT_SETTINGS: AnnotatorSettings = {
+    annotationModeByDefault: true,
     deafultDarkMode: false,
     darkReaderSettings: {
         brightness: 150,
@@ -72,6 +74,16 @@ export default class AnnotatorSettingsTab extends PluginSettingTab {
             );
 
         containerEl.createEl('h3', { text: 'Annotation Markdown Settings' });
+
+        new Setting(containerEl)
+            .setName('Use Annotation Mode By Default')
+            .setDesc('Whether to use annotation mode by default when opening a note with annotation-target')
+            .addToggle(toggle =>
+                toggle.setValue(this.plugin.settings.annotationModeByDefault).onChange(async value => {
+                    this.plugin.settings.annotationModeByDefault = value;
+                    await this.plugin.saveSettings();
+                })
+            );
 
         new Setting(containerEl)
             .setName('Include Prefix')

--- a/tests/annotationUtils.test.ts
+++ b/tests/annotationUtils.test.ts
@@ -6,12 +6,12 @@ import { Annotation } from '../src/types';
 
 const testAnnotatorSettings: IHasAnnotatorSettings = {
     settings: {
-        annotationModeByDefault: true,
         deafultDarkMode: false,
         darkReaderSettings: null,
         debugLogging: false,
         customDefaultPath: null,
         annotationMarkdownSettings: {
+            annotationModeByDefault: true,
             includePostfix: true,
             includePrefix: true,
             highlightHighlightedText: true

--- a/tests/annotationUtils.test.ts
+++ b/tests/annotationUtils.test.ts
@@ -6,6 +6,7 @@ import { Annotation } from '../src/types';
 
 const testAnnotatorSettings: IHasAnnotatorSettings = {
     settings: {
+        annotationModeByDefault: true,
         deafultDarkMode: false,
         darkReaderSettings: null,
         debugLogging: false,


### PR DESCRIPTION
I have my thoughts in notes with pdf/epub files like a summary, opinion, critic from other sources, etc. In my experience, it's really annoying to see a document with annotations instead of pure markdown with my thoughts. So, I've added a setting to configure this behavior.

I'm not sure if this problem annoys only me or most of the users, so I decided not to change the current behavior.