### PR TITLE
Infinite scroll for Epub reader

### DIFF
--- a/Modified Resources.md
+++ b/Modified Resources.md
@@ -29,6 +29,7 @@ The following resources have been modified in the (`resources`) folder, and will
     switch (readerSettings.readingMode) {
       case "scroll":
         document.querySelectorAll("a.arrow").forEach((e) => e.remove());
+        document.querySelector("#viewer").classList.add("hide-after");
         break;
 
       case "pagination":
@@ -46,6 +47,13 @@ The following resources have been modified in the (`resources`) folder, and will
 
         break;
     }
+    ```
+* `cdn.hypothes.is\demos\epub\epub.js\css\reader.css`
+    > Add `.hide-after` class. This is needed to hide page separator in Scroll view
+    ```css
+    .hide-after:after {
+        display: none;
+    };
     ```
 * `via.hypothes.is\https.html`
     > The `event.source` check has to be disabled for the loading progress bar to dissappear. 

--- a/Modified Resources.md
+++ b/Modified Resources.md
@@ -23,6 +23,30 @@ The following resources have been modified in the (`resources`) folder, and will
     ```js
     window.rendition = rendition; // expose the rendered epub object. 
     ```
+
+    > Add addEventListener for arrows only it's Pagination mdoe. Remove arrows if it's Scoll mode
+    ```js
+    switch (readerSettings.readingMode) {
+      case "scroll":
+        document.querySelectorAll("a.arrow").forEach((e) => e.remove());
+        break;
+
+      case "pagination":
+        var next = document.getElementById("next");
+        next.addEventListener("click", function(e){
+          rendition.next();
+          e.preventDefault();
+        }, false);
+
+        var prev = document.getElementById("prev");
+        prev.addEventListener("click", function(e){
+          rendition.prev();
+          e.preventDefault();
+        }, false);
+
+        break;
+    }
+    ```
 * `via.hypothes.is\https.html`
     > The `event.source` check has to be disabled for the loading progress bar to dissappear. 
     ```js

--- a/Modified Resources.md
+++ b/Modified Resources.md
@@ -1,6 +1,24 @@
 The following resources have been modified in the (`resources`) folder, and will need to be reapplied when updating hypothesis version. 
 
 * `cdn.hypothes.is\demos\epub\epub.js\js\reader.js`
+    > Expose `start()` function as `window.epubReader(readerSettings)`. It allows to pass settings to reader from `annotatorView`
+    ```js
+    window.epubReader = function (readerSettings) {
+        var readingMode = ({
+        'scroll': { manager: "continuous", flow: "scrolled" },
+        'pagination': { manager: "default", flow: "paginated" }
+    });
+    ```
+    > Pass reading mode settings to rendition. This is required for changing EPUB reader mode.
+    ```js
+    var rendition = book.renderTo("viewer", {
+      ...readingMode[readerSettings.readingMode],
+      ...
+      ...
+    ```
+
+    > REMOVE `document.addEventListener('DOMContentLoaded', start, false);` because `epubReader` function runs from `annotatorView` with params.
+
     > This is needed for switching EPUB pages 
     ```js
     window.rendition = rendition; // expose the rendered epub object. 
@@ -25,4 +43,3 @@ The following resources have been modified in the (`resources`) folder, and will
     > This fixes an issue with highlights not working:
       Replace `if(l||(l=new Set,this._sentChannels.set(i,l)),l.has(a))return;` from annotator.bundle.js
       with `if(l||(l=new Set,this._sentChannels.set(i,l)),l.has(a)){};`
-

--- a/resources/cdn.hypothes.is/demos/epub/epub.js/css/reader.css
+++ b/resources/cdn.hypothes.is/demos/epub/epub.js/css/reader.css
@@ -331,3 +331,7 @@ svg {
 #controls > input[type=range] {
     width: 400px;
 }
+
+.hide-after:after {
+  display: none;
+};

--- a/resources/cdn.hypothes.is/demos/epub/epub.js/js/reader.js
+++ b/resources/cdn.hypothes.is/demos/epub/epub.js/js/reader.js
@@ -33,6 +33,7 @@
     switch (readerSettings.readingMode) {
       case "scroll":
         document.querySelectorAll("a.arrow").forEach((e) => e.remove());
+        document.querySelector("#viewer").classList.add("hide-after");
         break;
 
       case "pagination":

--- a/resources/cdn.hypothes.is/demos/epub/epub.js/js/reader.js
+++ b/resources/cdn.hypothes.is/demos/epub/epub.js/js/reader.js
@@ -30,18 +30,26 @@
 
     rendition.display(hash || undefined);
 
+    switch (readerSettings.readingMode) {
+      case "scroll":
+        document.querySelectorAll("a.arrow").forEach((e) => e.remove());
+        break;
 
-    var next = document.getElementById("next");
-    next.addEventListener("click", function(e){
-      rendition.next();
-      e.preventDefault();
-    }, false);
+      case "pagination":
+        var next = document.getElementById("next");
+        next.addEventListener("click", function(e){
+          rendition.next();
+          e.preventDefault();
+        }, false);
 
-    var prev = document.getElementById("prev");
-    prev.addEventListener("click", function(e){
-      rendition.prev();
-      e.preventDefault();
-    }, false);
+        var prev = document.getElementById("prev");
+        prev.addEventListener("click", function(e){
+          rendition.prev();
+          e.preventDefault();
+        }, false);
+
+        break;
+    }
 
     var nav = document.getElementById("navigation");
     var opener = document.getElementById("opener");

--- a/resources/cdn.hypothes.is/demos/epub/epub.js/js/reader.js
+++ b/resources/cdn.hypothes.is/demos/epub/epub.js/js/reader.js
@@ -1,6 +1,9 @@
-(function() {
+  window.epubReader = function (readerSettings) {
+    var readingMode = ({
+      'scroll': { manager: "continuous", flow: "scrolled" },
+      'pagination': { manager: "default", flow: "paginated" }
+    });
 
-  function start() {
     var params = URLSearchParams && new URLSearchParams(document.location.search.substring(1));
     var url = params && params.get("url") && decodeURIComponent(params.get("url"));
 
@@ -11,6 +14,7 @@
       }
     });
     var rendition = book.renderTo("viewer", {
+      ...readingMode[readerSettings.readingMode],
       ignoreClass: "annotator-hl",
       width: "100%",
       height: "100%"
@@ -160,6 +164,3 @@
 
     });
   }
-
-  document.addEventListener('DOMContentLoaded', start, false);
-})();

--- a/src/annotatorView.tsx
+++ b/src/annotatorView.tsx
@@ -98,6 +98,10 @@ export default class AnnotatorView extends FileView {
                                 annotationFile={file.path}
                                 onload={async iframe => {
                                     this.iframe = iframe;
+                                    //(iframe.contentWindow as any).document
+                                        //.addEventListener('DOMContentLoaded',
+                                            //(iframe.contentWindow as any).epubReader(this.plugin.settings.epubSettings), false);
+                                    (iframe.contentWindow as any).epubReader(this.plugin.settings.epubSettings);
                                 }}
                                 onDarkReadersUpdated={this.onDarkReadersUpdated.bind(this)}
                             />

--- a/src/annotatorView.tsx
+++ b/src/annotatorView.tsx
@@ -98,9 +98,6 @@ export default class AnnotatorView extends FileView {
                                 annotationFile={file.path}
                                 onload={async iframe => {
                                     this.iframe = iframe;
-                                    //(iframe.contentWindow as any).document
-                                        //.addEventListener('DOMContentLoaded',
-                                            //(iframe.contentWindow as any).epubReader(this.plugin.settings.epubSettings), false);
                                     (iframe.contentWindow as any).epubReader(this.plugin.settings.epubSettings);
                                 }}
                                 onDarkReadersUpdated={this.onDarkReadersUpdated.bind(this)}

--- a/src/settings.tsx
+++ b/src/settings.tsx
@@ -9,6 +9,9 @@ export interface AnnotatorSettings {
         sepia: number;
     };
     customDefaultPath: string;
+    epubSettings: {
+        readingMode: "scroll" | "pagination";
+    };
     annotationMarkdownSettings: {
         annotationModeByDefault: boolean;
         includePrefix: boolean;
@@ -27,6 +30,9 @@ export const DEFAULT_SETTINGS: AnnotatorSettings = {
     },
     debugLogging: false,
     customDefaultPath: '',
+    epubSettings: {
+        readingMode: "pagination"
+    },
     annotationMarkdownSettings: {
         annotationModeByDefault: true,
         includePrefix: true,
@@ -71,6 +77,21 @@ export default class AnnotatorSettingsTab extends PluginSettingTab {
                     this.plugin.settings.customDefaultPath = value;
                     await this.plugin.saveSettings();
                 })
+            );
+
+        containerEl.createEl('h3', { text: 'Epub Reader Settings'});
+
+        new Setting(containerEl)
+            .setName('Epub reader mode')
+            .addDropdown(dropdown =>
+                dropdown
+                    .addOption("scroll", "Scroll")
+                    .addOption("pagination", "Pagination")
+                    .setValue(this.plugin.settings.epubSettings.readingMode)
+                    .onChange(async value => {
+                        this.plugin.settings.epubSettings.readingMode = value as "scroll" | "pagination";
+                        await this.plugin.saveSettings();
+                    })
             );
 
         containerEl.createEl('h3', { text: 'Annotation Markdown Settings' });

--- a/tests/annotationUtils.test.ts
+++ b/tests/annotationUtils.test.ts
@@ -10,6 +10,9 @@ const testAnnotatorSettings: IHasAnnotatorSettings = {
         darkReaderSettings: null,
         debugLogging: false,
         customDefaultPath: null,
+        epubSettings: {
+            readingMode: "scroll"
+        },
         annotationMarkdownSettings: {
             annotationModeByDefault: true,
             includePostfix: true,


### PR DESCRIPTION
PDF and EPUB readers behave differently at the moment. RDF shows a document as an infinite scroll, then EPUB shows a document page by page. I think they should work identically by default. This PR enables scroll view for EPUB.

## Current problem
I've made changes directly in epub.js demo dir only because I didn't find a way to patch it from the plugin codebase. Is it possible? Could you give a hint on how to do that?

## Preview
### Before
<img width="1080" alt="Screenshot 2022-01-17 at 08 04 23" src="https://user-images.githubusercontent.com/4015182/149710975-d3e7dd62-0c87-40b3-a84c-e1aa5a95fb11.png">

### After
<img width="1081" alt="Screenshot 2022-01-17 at 08 01 45" src="https://user-images.githubusercontent.com/4015182/149710987-ad8beffb-746d-4c19-9790-f8275cfd11b9.png">

