### PR TITLE
Change EPUB reader font size in settings

### DIFF
--- a/Modified Resources.md
+++ b/Modified Resources.md
@@ -22,6 +22,11 @@ The following resources have been modified in the (`resources`) folder, and will
 
     > REMOVE `document.addEventListener('DOMContentLoaded', start, false);` because `epubReader` function runs from `annotatorView` with params.
 
+    > Add this to change fontSize from plugin settings
+    ```js
+    rendition.themes.fontSize(`${readerSettings.fontSize}%`);
+    ```
+
     > This is needed for switching EPUB pages 
     ```js
     window.rendition = rendition; // expose the rendered epub object. 

--- a/resources/cdn.hypothes.is/demos/epub/epub.js/js/reader.js
+++ b/resources/cdn.hypothes.is/demos/epub/epub.js/js/reader.js
@@ -19,6 +19,7 @@
       width: "100%",
       height: "100%"
     });
+    rendition.themes.fontSize(`${readerSettings.fontSize}%`);
     window.rendition = rendition; 
 
     // var hash = window.location.hash.slice(2);

--- a/src/settings.tsx
+++ b/src/settings.tsx
@@ -33,7 +33,7 @@ export const DEFAULT_SETTINGS: AnnotatorSettings = {
     customDefaultPath: '',
     epubSettings: {
         readingMode: 'pagination',
-        fontSize: 16,
+        fontSize: 100,
     },
     annotationMarkdownSettings: {
         annotationModeByDefault: true,
@@ -96,15 +96,15 @@ export default class AnnotatorSettingsTab extends PluginSettingTab {
 
         const epubFontSize = new Setting(containerEl)
             .setName('Font Size')
-            .setDesc(`Base fron size in pixels. Current: ${this.plugin.settings.epubSettings.fontSize}`);
+            .setDesc(`Base fron size in percents. Current: ${this.plugin.settings.epubSettings.fontSize}%`);
 
         epubFontSize.addSlider(slider =>
             slider
-                .setLimits(8, 32, 2)
+                .setLimits(50, 200, 5)
                 .setValue(this.plugin.settings.epubSettings.fontSize)
                 .onChange(async value => {
                     this.plugin.settings.epubSettings.fontSize = value;
-                    epubFontSize.setDesc(`Base fron size in pixels. Current: ${this.plugin.settings.epubSettings.fontSize}`)
+                    epubFontSize.setDesc(`Base fron size in percents. Current: ${this.plugin.settings.epubSettings.fontSize}%`)
                     slider.setDynamicTooltip();
                     await this.plugin.saveSettings();
                 })

--- a/src/settings.tsx
+++ b/src/settings.tsx
@@ -11,6 +11,7 @@ export interface AnnotatorSettings {
     customDefaultPath: string;
     epubSettings: {
         readingMode: 'scroll' | 'pagination';
+        fontSize: number;
     };
     annotationMarkdownSettings: {
         annotationModeByDefault: boolean;
@@ -31,7 +32,8 @@ export const DEFAULT_SETTINGS: AnnotatorSettings = {
     debugLogging: false,
     customDefaultPath: '',
     epubSettings: {
-        readingMode: 'pagination'
+        readingMode: 'pagination',
+        fontSize: 16,
     },
     annotationMarkdownSettings: {
         annotationModeByDefault: true,
@@ -88,6 +90,22 @@ export default class AnnotatorSettingsTab extends PluginSettingTab {
                 .setValue(this.plugin.settings.epubSettings.readingMode)
                 .onChange(async value => {
                     this.plugin.settings.epubSettings.readingMode = value as 'scroll' | 'pagination';
+                    await this.plugin.saveSettings();
+                })
+        );
+
+        const epubFontSize = new Setting(containerEl)
+            .setName('Font Size')
+            .setDesc(`Base fron size in pixels. Current: ${this.plugin.settings.epubSettings.fontSize}`);
+
+        epubFontSize.addSlider(slider =>
+            slider
+                .setLimits(8, 32, 2)
+                .setValue(this.plugin.settings.epubSettings.fontSize)
+                .onChange(async value => {
+                    this.plugin.settings.epubSettings.fontSize = value;
+                    epubFontSize.setDesc(`Base fron size in pixels. Current: ${this.plugin.settings.epubSettings.fontSize}`)
+                    slider.setDynamicTooltip();
                     await this.plugin.saveSettings();
                 })
         );

--- a/tests/annotationUtils.test.ts
+++ b/tests/annotationUtils.test.ts
@@ -11,7 +11,8 @@ const testAnnotatorSettings: IHasAnnotatorSettings = {
         debugLogging: false,
         customDefaultPath: null,
         epubSettings: {
-            readingMode: "scroll"
+            readingMode: "scroll",
+            fontSize: 16
         },
         annotationMarkdownSettings: {
             annotationModeByDefault: true,


### PR DESCRIPTION
Add setting to plugin to change font size in EPUB reader. Setting use percents instead of pixels because that's how `rendition` API work. It's better to change font size on rendition level because it allows us to use multiple themes like lite/dark/etc without modifying them.

<img width="888" alt="Screenshot 2022-01-26 at 21 24 18" src="https://user-images.githubusercontent.com/4015182/151223737-bd4c6715-fd3a-4aae-84f9-5c21dd0d0f32.png">

<img width="1377" alt="Screenshot 2022-01-26 at 21 24 36" src="https://user-images.githubusercontent.com/4015182/151223776-d2a3bcc6-dfa1-4041-a39d-fd66927f4936.png">

