### PR TITLE
Fix internal link jump

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -334,7 +334,7 @@ export default class AnnotatorPlugin extends Plugin implements IHasAnnotatorSett
     private addMarkdownPostProcessor() {
         const markdownPostProcessor = async (el: HTMLElement, ctx: MarkdownPostProcessorContext) => {
             for (const link of el.getElementsByClassName('internal-link') as HTMLCollectionOf<HTMLAnchorElement>) {
-                const parsedLink = parseLinktext(link.href);
+                const parsedLink = parseLinktext(link.getAttribute("data-href"));
                 const annotationid = parsedLink.subpath.startsWith('#^') ? parsedLink.subpath.substr(2) : null;
                 const file: TFile | null = this.app.metadataCache.getFirstLinkpathDest(parsedLink.path, ctx.sourcePath);
 


### PR DESCRIPTION
Resolves #172, #230

Now the internal link jump, like clicking `show annotation` button or links from other files, can work.

---

Obsidian version: 0.15.9
OS: macOS 12.4