### PR TITLE
Enhancement: Free scrolling after jumping to the PDF annotation link

### DIFF
--- a/src/annotatorView.tsx
+++ b/src/annotatorView.tsx
@@ -217,6 +217,7 @@ export default class AnnotatorView extends FileView {
         const annotation = await getAnnotation(annotationId, this.file, this.app.vault);
         if (!annotation) return;
         let yoffset = -10000;
+        let done = false;
         let newYOffset;
         const isPageNote = !annotation.target?.length;
         const selectors = new Set(isPageNote ? [] : annotation.target[0].selector.map(x => JSON.stringify(x)));
@@ -277,7 +278,6 @@ export default class AnnotatorView extends FileView {
                         'showAnnotations',
                         matchingAnchors.map(x => x.annotation.$tag)
                     );
-                    let done = false;
                     switch (annotationTargetType) {
                         case 'pdf':
                             for (const anchor of matchingAnchors) {


### PR DESCRIPTION
Hey, @aladmit, @jonasmerlin, @elias-sundqvist and @rdimaio 
![lll](https://user-images.githubusercontent.com/45873697/201590556-b0ae5a67-44d0-4cfb-ab4e-11af25872fcb.gif)

**ps. Use [main.js](https://github.com/HardwayLinka/obsidian-annotator/releases/download/0.2.7patched/main.js) and [manifest.json](https://github.com/HardwayLinka/obsidian-annotator/releases/download/0.2.7patched/manifest.json) in [0.2.7patched](https://github.com/HardwayLinka/obsidian-annotator/releases/tag/0.2.7patched) to test without building the project**
