### PR TITLE
fixed 'Line breaks in highlights cause link to fail'

### DIFF
--- a/src/defineGenericAnnotation.tsx
+++ b/src/defineGenericAnnotation.tsx
@@ -425,7 +425,8 @@ export default (vault: Vault, plugin: AnnotatorPlugin) => {
                             );
                             if (matchingAnnotations.length > 0) {
                                 const annotation = matchingAnnotations[0];
-                                const { exact } = getAnnotationHighlightTextData(annotation);
+                                let { exact } = getAnnotationHighlightTextData(annotation);
+                                exact = exact.replace(/[\r\n]/g, ' ');
                                 plugin.dragData = {
                                     annotationFilePath: props.annotationFile,
                                     annotationId: annotation.id,


### PR DESCRIPTION
Hey @elias-sundqvist @aladmit, I fixed https://github.com/elias-sundqvist/obsidian-annotator/issues/267

![fixbug](https://user-images.githubusercontent.com/45873697/206714469-751baa78-df35-4ba7-99ce-3b0eb7259724.gif)
