### PR TITLE
add wikilink support for annotation target

### DIFF
--- a/src/annotatorView.tsx
+++ b/src/annotatorView.tsx
@@ -3,10 +3,10 @@ import { ANNOTATION_TARGET_PROPERTY, ANNOTATION_TARGET_TYPE_PROPERTY, VIEW_TYPE_
 import { DarkReaderType } from 'darkreader';
 import AnnotatorPlugin from 'main';
 import { Annotation } from './types';
-import { FileView, Menu, MenuItem, TFile, WorkspaceLeaf } from 'obsidian';
+import { FileView, Menu, MenuItem, TFile, WorkspaceLeaf, getLinkPath } from 'obsidian';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { isUrl, get_url_extension } from 'utils';
+import { isUrl, get_url_extension, getWikilink } from 'utils';
 
 export default class AnnotatorView extends FileView {
     plugin: AnnotatorPlugin;
@@ -45,6 +45,10 @@ export default class AnnotatorView extends FileView {
             }
             let destFile: TFile;
             try {
+                const wikilink = getWikilink(target);
+                if (wikilink) {
+                    target = getLinkPath(target);
+                }
                 destFile = this.app.metadataCache.getFirstLinkpathDest(target, file?.path || '');
             } finally {
                 if (destFile) {

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -53,6 +53,21 @@ export function isUrl(potentialUrl: string) {
     }
 }
 
+/**
+ * If the given string is a wikilink, return the link content, otherwise return null
+ * Ex: "[[Some File]]", returns "Some File"
+ */
+export function getWikilink(potentialWikilink: string): string | null {
+    if (!potentialWikilink) {
+        return null;
+    }
+    const match = potentialWikilink.match(/^\[\[(.*)\]\]$/);
+    if (!match) {
+        return null;
+    }
+    return match[1];
+}
+
 export function utf8_to_b64(str) {
     return window.btoa(unescape(encodeURIComponent(str)));
 }


### PR DESCRIPTION
Adds wikilink support for annotation targets.

Note to maintainer ... I haven't actually tested this. I'm on an arm Mac, which doesn't get canvas binaries prebuilt. I couldn't get it building, so I couldn't get a complete `npm install`, and therefore a complete build. Apologies for opening a PR in that state, but it's the best I could do at the moment and seemed an otherwise easy improvement to make.

However, it's a fairly straightforward change, at least assuming [this discord message](https://discord.com/channels/686053708261228577/840286264964022302/1086064814062837840) about how to resolve wikilinks is still accurate.

This would resolve #318 