### PR TITLE
Add "allow-modals" to sandbox to enable print dialog

### DIFF
--- a/src/defineGenericAnnotation.tsx
+++ b/src/defineGenericAnnotation.tsx
@@ -504,7 +504,7 @@ export default (vault: Vault, plugin: AnnotatorPlugin) => {
                 outerIframeProps={{
                     height: '100%',
                     width: '100%',
-                    sandbox: 'allow-same-origin allow-scripts allow-presentation'
+                    sandbox: 'allow-same-origin allow-scripts allow-presentation allow-modals'
                 }}
             />
         );


### PR DESCRIPTION
This adds "allow-modals" to the sandbox parameters so that the print dialog can display.
